### PR TITLE
Fixed: Missing trackers when packets are split & packets could be larger than MaxPacketLength

### DIFF
--- a/src/DBDesign.PosiStageDotNet/PsnServer.cs
+++ b/src/DBDesign.PosiStageDotNet/PsnServer.cs
@@ -467,18 +467,16 @@ namespace DBDesign.PosiStageDotNet
 
 			foreach (var chunk in trackerChunks)
 			{
-				if (trackerListLength <= maxTrackerListLength)
-				{
-					currentTrackerList.Add(chunk);
-					trackerListLength += chunk.ChunkAndHeaderLength;
-				}
-				else
-				{
-					trackerListChunks.Add(new PsnDataTrackerListChunk(currentTrackerList));
-					currentTrackerList = new List<PsnDataTrackerChunk>();
-					trackerListLength = 0;
-				}
-			}
+				if (trackerListLength + chunk.ChunkAndHeaderLength > maxTrackerListLength)
+                {
+                    trackerListChunks.Add(new PsnDataTrackerListChunk(currentTrackerList));
+                    currentTrackerList = new List<PsnDataTrackerChunk>();
+                    trackerListLength = 0;
+                }
+
+                currentTrackerList.Add(chunk);
+                trackerListLength += chunk.ChunkAndHeaderLength;
+            }
 
 			trackerListChunks.Add(new PsnDataTrackerListChunk(currentTrackerList));
 


### PR DESCRIPTION
Hello David,

We got a bug report on the PSN C++ repo (https://github.com/vyv/psn-cpp/issues/6). It ended up being related to the .NET implementation of PSN. I decided to take a look at it myself and found the issue. I implemented a solution for it. I also fixed the packet size since I was hitting assertions while debugging.

Cheers,
Gilles-Philippe Paillé
VYV Corporation

----

1) When the size of a packet gets larger than MaxPacketLength, the tracker creating the overflow was not added to the list.

2) The comparison with MaxPacketLength was done without the size of the tracker to be added, leading to a packet size slightly larger than the max packet size as defined in the PSN specs. This is relatively bening, but still worth fixing.